### PR TITLE
Support for transactions & castable results

### DIFF
--- a/Simple.Data.RawSql/AdoAdapterExtensions.cs
+++ b/Simple.Data.RawSql/AdoAdapterExtensions.cs
@@ -6,9 +6,8 @@ using Simple.Data.Extensions;
 
 namespace Simple.Data.RawSql
 {
-    public static class AdoAdapterExtensions
+    internal static class AdoAdapterExtensions
     {
-
         public static IEnumerable<IEnumerable<dynamic>> ToResultSets(
             this AdoAdapter adapter,
             string sql,

--- a/Simple.Data.RawSql/DataReaderExtensions.cs
+++ b/Simple.Data.RawSql/DataReaderExtensions.cs
@@ -5,7 +5,7 @@ using Simple.Data.Ado;
 
 namespace Simple.Data.RawSql
 {
-    public static class DataReaderExtensions
+    internal static class DataReaderExtensions
     {
         public static IEnumerable<IEnumerable<dynamic>> ToResultSets(this IDataReader reader)
         {
@@ -37,14 +37,14 @@ namespace Simple.Data.RawSql
             return record.ToDictionary().Single().Value;
         }
 
-        private static IEnumerable<IEnumerable<SimpleRecord>> ToResultSets(this IEnumerable<IEnumerable<IDictionary<string, object>>> data)
+        private static IEnumerable<IEnumerable<dynamic>> ToResultSets(this IEnumerable<IEnumerable<IDictionary<string, object>>> data)
         {
             return data.Select(ToRows).ToArray().AsEnumerable();
         }
 
-        private static IEnumerable<SimpleRecord> ToRows(this IEnumerable<IDictionary<string, object>> rsData)
+        private static IEnumerable<dynamic> ToRows(this IEnumerable<IDictionary<string, object>> rsData)
         {
-            return rsData.Select(ToRow).ToArray().AsEnumerable();
+            return new SimpleList(rsData.Select(ToRow).ToArray().AsEnumerable());
         }
 
         private static SimpleRecord ToRow(this IDictionary<string, object> rowData)

--- a/Simple.Data.RawSql/DatabaseExtensions.cs
+++ b/Simple.Data.RawSql/DatabaseExtensions.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Data;
-using System.Dynamic;
 using Simple.Data.Ado;
 using Simple.Data.Extensions;
 
@@ -9,7 +7,6 @@ namespace Simple.Data.RawSql
 {
     public static class DatabaseExtensions
     {
-
         public static IEnumerable<IEnumerable<dynamic>> ToResultSets(
             this Database db,
             string sql,
@@ -33,7 +30,7 @@ namespace Simple.Data.RawSql
         public static IEnumerable<dynamic> ToRows(this Database db, string sql,
                                                   IDictionary<string, object> parameters)
         {
-            return db.GetAdoAdapter().ToRows(sql, parameters);
+            return new SimpleList(db.GetAdoAdapter().ToRows(sql, parameters));
         }
 
         public static IEnumerable<dynamic> ToRows(this Database db, string sql,
@@ -103,6 +100,5 @@ namespace Simple.Data.RawSql
                 throw new NotSupportedException("Only Simple.Data.Ado adapters are supported by Simple.Data.RawSql");
             return adoAdapter;
         }
-
     }
 }

--- a/Simple.Data.RawSql/DbCommandBuilder.cs
+++ b/Simple.Data.RawSql/DbCommandBuilder.cs
@@ -5,9 +5,8 @@ using Simple.Data.Extensions;
 
 namespace Simple.Data.RawSql
 {
-    public class DbCommandBuilder
+    internal class DbCommandBuilder
     {
-
         public IDbCommand BuildCommand(IDbConnection connection, string sql, object parameters)
         {
             return BuildCommand(connection, sql, parameters.ObjectToDictionary());

--- a/Simple.Data.RawSql/DbCommandExtensions.cs
+++ b/Simple.Data.RawSql/DbCommandExtensions.cs
@@ -6,7 +6,7 @@ using Simple.Data.Extensions;
 
 namespace Simple.Data.RawSql
 {
-    public static class DbCommandExtensions
+    internal static class DbCommandExtensions
     {
         public static IEnumerable<IEnumerable<dynamic>> ToResultSets(this IDbCommand command)
         {

--- a/Simple.Data.RawSql/DbConnectionExtensions.cs
+++ b/Simple.Data.RawSql/DbConnectionExtensions.cs
@@ -1,14 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Linq;
 using Simple.Data.Extensions;
 
 namespace Simple.Data.RawSql
 {
-    public static class DbConnectionExtensions
+    internal static class DbConnectionExtensions
     {
-
         private const string SqlEmptyOrWhitespace = "Sql statement can't be empty or whitespace.";
 
         public static IEnumerable<IEnumerable<dynamic>> ToResultSets(this IDbConnection connection, string sql,

--- a/Simple.Data.RawSql/Simple.Data.RawSql.csproj
+++ b/Simple.Data.RawSql/Simple.Data.RawSql.csproj
@@ -53,6 +53,7 @@
     <Compile Include="DbCommandExtensions.cs" />
     <Compile Include="DbConnectionExtensions.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="SimpleTransactionExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.config" />

--- a/Simple.Data.RawSql/SimpleTransactionExtensions.cs
+++ b/Simple.Data.RawSql/SimpleTransactionExtensions.cs
@@ -1,0 +1,97 @@
+﻿using System;
+using System.Collections.Generic;
+using Simple.Data.Ado;
+using Simple.Data.Extensions;
+
+namespace Simple.Data.RawSql {
+    public static class SimpleTransactionExtensions
+    {
+        public static IEnumerable<IEnumerable<dynamic>> ToResultSets(
+            this SimpleTransaction db,
+            string sql,
+            IDictionary<string, object> parameters)
+        {
+            return db.GetAdoAdapter().ToResultSets(sql, parameters);
+        }
+
+        public static IEnumerable<IEnumerable<dynamic>> ToResultSets(this SimpleTransaction db, string sql,
+            params KeyValuePair<string, object>[] parameters)
+        {
+            return db.ToResultSets(sql, parameters.ToDictionary());
+        }
+
+        public static IEnumerable<IEnumerable<dynamic>> ToResultSets(this SimpleTransaction db, string sql, object parameters)
+        {
+            return db.ToResultSets(sql, parameters.ObjectToDictionary());
+        }
+
+        public static IEnumerable<dynamic> ToRows(this SimpleTransaction db, string sql, IDictionary<string, object> parameters)
+        {
+            return db.GetAdoAdapter().ToRows(sql, parameters);
+        }
+
+        public static IEnumerable<dynamic> ToRows(this SimpleTransaction db, string sql, params KeyValuePair<string, object>[] parameters)
+        {
+            return db.ToRows(sql, parameters.ToDictionary());
+        }
+
+        public static dynamic ToRows(this SimpleTransaction db, string sql, object parameters)
+        {
+            return new SimpleList(db.ToRows(sql, parameters.ObjectToDictionary()));
+        }
+
+        public static dynamic ToRow(this SimpleTransaction db, string sql, IDictionary<string, object> parameters)
+        {
+            return db.GetAdoAdapter().ToRow(sql, parameters);
+        }
+
+        public static dynamic ToRow(this SimpleTransaction db, string sql, params KeyValuePair<string, object>[] parameters)
+        {
+            return db.ToRow(sql, parameters.ToDictionary());
+        }
+
+        public static dynamic ToRow(this SimpleTransaction db, string sql, object parameters)
+        {
+            return db.ToRow(sql, parameters.ObjectToDictionary());
+        }
+
+        public static object ToScalar(this SimpleTransaction db, string sql, IDictionary<string, object> parameters)
+        {
+            return db.GetAdoAdapter().ToScalar(sql, parameters);
+        }
+
+        public static object ToScalar(this SimpleTransaction db, string sql, params KeyValuePair<string, object>[] parameters)
+        {
+            return db.GetAdoAdapter().ToScalar(sql, parameters.ToDictionary());
+        }
+
+        public static object ToScalar(this SimpleTransaction db, string sql, object parameters)
+        {
+            return db.GetAdoAdapter().ToScalar(sql, parameters.ObjectToDictionary());
+        }
+
+        public static int Execute(this SimpleTransaction db, string sql, IDictionary<string, object> parameters)
+        {
+            return db.GetAdoAdapter().ExecuteNonQuery(sql, parameters);
+        }
+
+        public static int Execute(this SimpleTransaction db, string sql, params KeyValuePair<string, object>[] parameters)
+        {
+            return db.GetAdoAdapter().ExecuteNonQuery(sql, parameters.ToDictionary());
+        }
+
+        public static int Execute(this SimpleTransaction db, string sql, object parameters)
+        {
+            return db.GetAdoAdapter().ExecuteNonQuery(sql, parameters.ObjectToDictionary());
+        }
+
+        private static AdoAdapter GetAdoAdapter(this SimpleTransaction db)
+        {
+            var adapter = db.GetAdapter();
+            var adoAdapter = adapter as AdoAdapter;
+            if (adoAdapter == null)
+                throw new NotSupportedException("Only Simple.Data.Ado adapters are supported by Simple.Data.RawSql");
+            return adoAdapter;
+        }
+    }
+}


### PR DESCRIPTION
Added support for SimpleTransactions.

ToRows now returns a SimpleList so this is possible:
IEnumerable entities = db.ToRows("SELECT \* FROM MyTable");

Some cleanup, made internal, line breaks etc.
